### PR TITLE
Update ie_api.pyx

### DIFF
--- a/inference-engine/ie_bridges/python/inference_engine/ie_api.pyx
+++ b/inference-engine/ie_bridges/python/inference_engine/ie_api.pyx
@@ -293,7 +293,7 @@ cdef class IEPlugin:
         version = bytes(self.impl.version)
         return version.decode()
 
-    cpdef void add_cpu_extension(self, extension_path: str) except *:
+    cpdef void add_cpu_extension(self, str extension_path) except *:
         if self.device.find("CPU") == -1:
             raise RuntimeError("add_cpu_extension method applicable only for CPU or HETERO devices")
         cdef string extension_str = extension_path.encode()


### PR DESCRIPTION
Fix error: dldt/inference-engine/ie_bridges/python/inference_engine/ie_api.pyx:296:10: Signature not compatible with previous declaration