### PR TITLE
Install sample apps & CMake Fixes for Clear Linux

### DIFF
--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -144,6 +144,16 @@ endif(UNIX)
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(thirdparty)
+
+if (INSTALL_SAMPLE_APPS)
+    #Install cpp samples
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/samples/ DESTINATION share/openvino/inference_engine/cpp_samples/
+    PATTERN "CMakeCache.txt" EXCLUDE PATTERN "CMakeFiles" EXCLUDE PATTERN "cmake_install.cmake" EXCLUDE PATTERN "Makefile" EXCLUDE)
+
+    #Install python samples
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ie_bridges/python/sample/ DESTINATION share/openvino/inference_engine/python_samples)
+endif()
+
 if (ENABLE_SAMPLES_CORE)
     set(InferenceEngine_DIR "${CMAKE_BINARY_DIR}")
 

--- a/inference-engine/src/CMakeLists.txt
+++ b/inference-engine/src/CMakeLists.txt
@@ -7,6 +7,8 @@
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 ####################################
+set(ConfigPackageLocation lib64/cmake/InferenceEngine)
+set(EXPORT_NAME inference_engine)
 
 add_subdirectory(inference_engine)
 
@@ -33,5 +35,8 @@ set(InferenceEngine_SRC_DIRS ${CMAKE_SOURCE_DIR}/src)
 function(set_target_cpu_flags TARGET_NAME)
 endfunction()
 
-add_subdirectory(extension EXCLUDE_FROM_ALL)
+add_subdirectory(extension)
+install(EXPORT ${EXPORT_NAME} DESTINATION ${ConfigPackageLocation} NAMESPACE IE:: FILE targets.cmake)
+
 add_library(IE::ie_cpu_extension ALIAS ie_cpu_extension)
+

--- a/inference-engine/src/extension/CMakeLists.txt
+++ b/inference-engine/src/extension/CMakeLists.txt
@@ -31,11 +31,17 @@ set_target_properties(${TARGET_NAME} PROPERTIES OUTPUT_NAME "cpu_extension")
 
 target_link_libraries(${TARGET_NAME} PRIVATE ${InferenceEngine_LIBRARIES})
 
-target_include_directories(${TARGET_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${TARGET_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include/${TARGET_NAME}>)
+
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_PDB_NAME ${TARGET_NAME})
 
 set_target_cpu_flags(${TARGET_NAME})
 
 if (IE_MAIN_SOURCE_DIR)
     export(TARGETS ${TARGET_NAME} NAMESPACE IE:: APPEND FILE "${CMAKE_BINARY_DIR}/targets.cmake")
+    install(TARGETS ${TARGET_NAME} EXPORT ${EXPORT_NAME} LIBRARY DESTINATION lib64)
+    install(FILES ext_base.hpp ext_list.hpp DESTINATION include/${TARGET_NAME})
 endif()
+

--- a/inference-engine/src/inference_engine/CMakeLists.txt
+++ b/inference-engine/src/inference_engine/CMakeLists.txt
@@ -67,7 +67,9 @@ set_ie_threading_interface_for(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} PRIVATE pugixml fluid ade ${CMAKE_DL_LIBS} ${INTEL_ITT_LIBS})
 
 # Properties->C/C++->General->Additional Include Directories
-target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_HEADERS_DIR}
+target_include_directories(${TARGET_NAME} PUBLIC
+                                          $<BUILD_INTERFACE:${IE_MAIN_SOURCE_DIR}/include>
+                                          $<INSTALL_INTERFACE:include/${TARGET_NAME}>
                                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
                                                   "${IE_MAIN_SOURCE_DIR}/src/dumper")
 
@@ -119,3 +121,11 @@ configure_file(
     "${CMAKE_SOURCE_DIR}/cmake/share/InferenceEngineConfig-version.cmake.in"
     "${CMAKE_BINARY_DIR}/InferenceEngineConfig-version.cmake"
     COPYONLY)
+
+install(TARGETS ${TARGET_NAME} EXPORT ${EXPORT_NAME} LIBRARY DESTINATION lib64)
+install(DIRECTORY ${PUBLIC_HEADERS_DIR}/ DESTINATION include/${TARGET_NAME} FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+install(FILES
+    "${CMAKE_BINARY_DIR}/InferenceEngineConfig.cmake"
+    "${CMAKE_BINARY_DIR}/InferenceEngineConfig-version.cmake"
+    DESTINATION ${ConfigPackageLocation})
+


### PR DESCRIPTION
 - Install cpp and python apps when INSTALL_SAMPLE_APPS
   flag is enabled.

 - CMake fixes for building and running samples on
   Clear Linux.