### PR TITLE
Bugfix: fix cmake ENABLE_TESTS flag (make disabling of IE tests compilation possible)

### DIFF
--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -139,7 +139,9 @@ include(CheckCXXCompilerFlag)
 include(cpplint)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+if (NOT DISABLE_IE_TESTS)
+    add_subdirectory(tests)
+endif()
 add_subdirectory(thirdparty)
 set(InferenceEngine_DIR "${CMAKE_BINARY_DIR}")
 

--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -139,7 +139,7 @@ include(CheckCXXCompilerFlag)
 include(cpplint)
 
 add_subdirectory(src)
-if (NOT DISABLE_IE_TESTS)
+if (ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 add_subdirectory(thirdparty)


### PR DESCRIPTION
Save compilation time -- add an option to not make all IE tests.