### PR TITLE
add specific requirement for rnn when the seq = 1.

### DIFF
--- a/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
+++ b/inference-engine/src/mkldnn_plugin/nodes/mkldnn_rnn.cpp
@@ -230,10 +230,19 @@ void MKLDNNRNN::fillSeqDesc() {
     }
 
     if (outs.size() > 1) {
-        for (int i = 1; i < outs.size(); i++)
-            if (getChildEdgeAt(i)->getDims() != S_shape)
-                THROW_IE_EXCEPTION << "Incorrect shape of state ports for layer " << getName();
-
+        if (T == 1)
+        {
+            MKLDNNDims S_shape_out {T, N, SC};
+            for (int i = 1; i < outs.size(); i++)
+                if (getChildEdgeAt(i)->getDims() != S_shape_out)
+                    THROW_IE_EXCEPTION << "Incorrect shape of state ports for layer " << getName() << "when seq = 1.";
+        }
+        else
+        {
+            for (int i = 1; i < outs.size(); i++)
+                if (getChildEdgeAt(i)->getDims() != S_shape)
+                    THROW_IE_EXCEPTION << "Incorrect shape of state ports for layer " << getName();
+        }
         out_state_d = {{L, D, S, N, SC}, memory::f32, memory::ldsnc};
     }
 


### PR DESCRIPTION
The line 459 ~ 461 of ["optimizer/mo/middle/passes/shape.py."](https://github.com/opencv/dldt/blob/b235c73481a6f133e1d182d91e5e2c29e8a460e5/model-
optimizer/mo/middle/passes/shape.py#L459) will measure the reshape is useless or not. However, when MO convert the onnx model which have rnn layer with sequence is 1, the MO will measure the reshape node of output of hidden state was useless so that the dims of input and output of hidden state was different.
 
Below was the log of MO when convert the onnx model and the converted IR model which have rnn layer with sequence = 1.

[ 2019-05-21 14:01:54,804 ] [ DEBUG ] [ shape:434 ]  First phase for Reshape: 42/CellStateResize
[ 2019-05-21 14:02:26,403 ] [ DEBUG ] [ shape:460 ]  Useless reshape with dim [ 1  1 20] was deleted: 42/SqueezeNumDirections/1
[ 2019-05-21 14:02:26,407 ] [ DEBUG ] [ shape:460 ]  Useless reshape with dim [ 1  1 20] was deleted: 42/SqueezeNumDirections/2

![Capture](https://user-images.githubusercontent.com/23442770/58156416-9c4aab80-7ca8-11e9-9b0b-85c041723add.JPG)

By this the dims of input and output of hidden state was different and it will make IE core dump since IE will check the dim of input and output of hidden state before inference. 

If not modify this part, IE will core dump when it infer the rnn model with seq = 1. 

