### PR TITLE
Bugfix: fix cmake ENABLE_TESTS flag

### DIFF
--- a/inference-engine/CMakeLists.txt
+++ b/inference-engine/CMakeLists.txt
@@ -139,7 +139,9 @@ include(CheckCXXCompilerFlag)
 include(cpplint)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+if (ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
 add_subdirectory(thirdparty)
 set(InferenceEngine_DIR "${CMAKE_BINARY_DIR}")
 


### PR DESCRIPTION
Save compilation time -- fix an option to not make all IE tests.

#139 
